### PR TITLE
Add support for product sections

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -102,6 +102,8 @@ copyright = "| Copyright &copy; 2019 [Gethugothemes](https://gethugothemes.com) 
 # Snipcart Credentials
 snipcartApiKey = "M2E5YjA3NjMtYzRiYS00YzVjLWEyYWYtNDY5ZDI0OWZhYjg5"
 currencySymbol = "$"
+# whether to show product sections among products
+showProductSections = true
 
   # Preloader
   [params.preloader]

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -167,12 +167,20 @@
         {{ end }}
       </div>
       {{ range first 6 (where site.RegularPages "Type" "products") }}
+      {{ $image := "" }}
+      {{ if .Params.Image }}
+        {{ $image = .Params.Image | absURL }}
+      {{ else }}
+        {{ if .Params.Images }}
+          {{ range first 1 .Params.Images }}
+            {{ $image = .image | absURL }}
+          {{ end }}
+        {{ end }}
+      {{ end }}
       <div class="col-lg-4 col-sm-6 mb-4">
         <div class="card border-0 text-center">
           <a href="{{ .Permalink }}">
-            {{ range first 1 .Params.Images }}
-            <img src="{{ .image | absURL }}" alt="{{ .Title }}" class="card-img-top">
-            {{ end }}
+            <img src="{{ $image }}" alt="{{ .Title }}" class="card-img-top">
           </a>
           <div class="card-body">
             <a href="{{ .Permalink }}" class="h4">{{ .Title }}</a>
@@ -184,7 +192,7 @@
               <span class="lead text-primary">{{ site.Params.currencySymbol }}{{ .Params.Price }}</span>
             </div>
             <button class="snipcart-add-item btn btn-sm btn-outline-primary" data-item-id="{{ .Params.ProductID }}"
-              data-item-name="{{ .Title }}" {{ range first 1 .Params.Images }} data-item-image="{{ .image | absURL }}"
+              data-item-name="{{ .Title }}" {{ range first 1 .Params.Images }} data-item-image="{{ $image }}"
               {{ end }} data-item-price="{{ .Params.Price }}" data-item-url="{{ .Permalink }}" data-item-description="{{ .Description }}">
               Add to cart
             </button>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -167,6 +167,7 @@
         {{ end }}
       </div>
       {{ range first 6 (where site.RegularPages "Type" "products") }}
+      {{ if not .IsSection }}
       {{ $image := "" }}
       {{ if .Params.Image }}
         {{ $image = .Params.Image | absURL }}
@@ -199,6 +200,7 @@
           </div>
         </div>
       </div>
+      {{ end }}
       {{ end }}
     </div>
   </div>

--- a/layouts/products/list.html
+++ b/layouts/products/list.html
@@ -6,7 +6,7 @@
   <div class="container">
     <div class="row">
       {{ range .Data.Pages }}
-      {{ if not .IsSection }}
+      {{ if site.Params.showProductSections | or (not .IsSection) }}
       {{ $image := "" }}
       {{ if .Params.Image }}
         {{ $image = .Params.Image | absURL }}

--- a/layouts/products/list.html
+++ b/layouts/products/list.html
@@ -6,12 +6,21 @@
   <div class="container">
     <div class="row">
       {{ range .Data.Pages }}
+      {{ if not .IsSection }}
+      {{ $image := "" }}
+      {{ if .Params.Image }}
+        {{ $image = .Params.Image | absURL }}
+      {{ else }}
+        {{ if .Params.Images }}
+          {{ range first 1 .Params.Images }}
+            {{ $image = .image | absURL }}
+          {{ end }}
+        {{ end }}
+      {{ end }}
       <div class="col-lg-4 col-sm-6 mb-4">
         <div class="card border-0 text-center">
           <a href="{{ .Permalink }}">
-            {{ range first 1 .Params.Images }}
-            <img src="{{ .image | absURL }}" alt="{{ .Title }}" class="card-img-top">
-            {{ end }}
+            <img src="{{ $image }}" alt="{{ .Title }}" class="card-img-top">
           </a>
           <div class="card-body">
             <a href="{{ .Permalink }}" class="h4">{{ .Title }}</a>
@@ -23,13 +32,14 @@
               <span class="lead text-primary">{{ site.Params.currencySymbol }}{{ .Params.Price }}</span>
             </div>
             <button class="snipcart-add-item btn btn-sm btn-outline-primary" data-item-id="{{ .Params.ProductID }}"
-              data-item-name="{{ .Title }}" {{ range first 1 .Params.Images }} data-item-image="{{ .image | absURL }}"
-              {{ end }} data-item-price="{{ .Params.Price }}" data-item-url="{{ .Permalink }}" data-item-description="{{ .Description }}">
+              data-item-name="{{ .Title }}" data-item-image="{{ $image }}"
+              data-item-price="{{ .Params.Price }}" data-item-url="{{ .Permalink }}" data-item-description="{{ .Description }}">
               Add to cart
             </button>
           </div>
         </div>
       </div>
+      {{ end }}
       {{ end }}
     </div>
   </div>

--- a/layouts/products/list.html
+++ b/layouts/products/list.html
@@ -25,6 +25,7 @@
           <div class="card-body">
             <a href="{{ .Permalink }}" class="h4">{{ .Title }}</a>
             <p>{{ .Params.Description }}</p>
+            {{ if .Params.Price }}
             <div class="mb-4">
               {{ if .Params.PriceBefore }}
               <s>{{ site.Params.currencySymbol }}{{ .Params.PriceBefore }}</s>
@@ -36,6 +37,7 @@
               data-item-price="{{ .Params.Price }}" data-item-url="{{ .Permalink }}" data-item-description="{{ .Description }}">
               Add to cart
             </button>
+            {{ end }}
           </div>
         </div>
       </div>

--- a/layouts/products/single.html
+++ b/layouts/products/single.html
@@ -5,6 +5,15 @@
 <section class="section pt-0">
   <div class="container">
     <div class="row">
+      {{ $image := "" }}
+      {{ if .Params.Image }}
+        {{ $image = .Params.Image | absURL }}
+      {{ else }}
+        {{ range first 1 .Params.Images }}
+          {{ $image = .image | absURL }}
+        {{ end }}
+      {{ end }}
+
       <div class="col-lg-5 mb-4 mb-lg-0">
         <!-- product image slider -->
         <div class="product-slider">
@@ -30,7 +39,7 @@
         <h5>Short Description</h5>
         <p>{{ .Params.ShortDescription | markdownify }}</p>
         <button class="snipcart-add-item btn btn-primary" data-item-id="{{ .Params.ProductID }}"
-          data-item-name="{{ .Title }}" {{ range first 1 .Params.Images }} data-item-image="{{ .image | absURL }}"
+          data-item-name="{{ .Title }}" {{ range first 1 .Params.Images }} data-item-image="{{ $image }}"
           {{ end }} data-item-price="{{ .Params.Price }}" data-item-url="{{ .Permalink }}" data-item-description="{{ .Description }}">
           Add to cart
         </button>


### PR DESCRIPTION
Allow products to be organised into sections.
Each section can have an `image` set to be displayed in the list when `showProductSections` is set.
Each product can also have `image` configured which is used instead of the first product image in the list (this can be a smaller image to save on a file size).

This would fix #38